### PR TITLE
preserve_client_ip set to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "aws_lb_target_group" "target_groups" {
   port                 = var.listeners[count.index]["target_port"]
   protocol             = "TCP"
   vpc_id               = var.vpc_id
+  preserve_client_ip   = false
 
   health_check {
     interval            = var.health_check_interval


### PR DESCRIPTION
This is needed for getting NLB to work with NGINX ingress controller

preserve_client_ip attribute - Preserves client IP addresses and ports in the packets forwarded to targets but enabling this fails nginx traffic flow.